### PR TITLE
Expose Opus NativeMethods library loader

### DIFF
--- a/MumbleSharp/Audio/Codecs/Opus/NativeMethods.cs
+++ b/MumbleSharp/Audio/Codecs/Opus/NativeMethods.cs
@@ -49,7 +49,8 @@ namespace MumbleSharp.Audio.Codecs.Opus
                 AppDomain.CurrentDomain.BaseDirectory,
                 Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Audio", "Codecs", "Opus", "Libs", Environment.Is64BitProcess ? "64bit" : "32bit")
             };
-            if(additionalSearchDirectories != null)
+
+            if (additionalSearchDirectories != null)
             {
                 searchDirectories.AddRange(additionalSearchDirectories);
             }

--- a/MumbleSharp/Audio/Codecs/Opus/NativeMethods.cs
+++ b/MumbleSharp/Audio/Codecs/Opus/NativeMethods.cs
@@ -34,15 +34,25 @@ namespace MumbleSharp.Audio.Codecs.Opus
     /// <summary>
     /// Wraps the Opus API.
     /// </summary>
-    internal class NativeMethods
+    public class NativeMethods
     {
+
         static NativeMethods()
+        {
+            LoadLibrary();
+        }
+
+        public static bool LoadLibrary(List<string> additionalSearchDirectories = null)
         {
             var searchDirectories = new List<string>
             {
                 AppDomain.CurrentDomain.BaseDirectory,
                 Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Audio", "Codecs", "Opus", "Libs", Environment.Is64BitProcess ? "64bit" : "32bit")
             };
+            if(additionalSearchDirectories != null)
+            {
+                searchDirectories.AddRange(additionalSearchDirectories);
+            }
 
             foreach (var searchDirectory in searchDirectories)
             {
@@ -68,11 +78,11 @@ namespace MumbleSharp.Audio.Codecs.Opus
                 if (File.Exists(libraryPath))
                 {
                     Load(libraryPath);
-                    return;
+                    return true;
                 }
             }
 
-            throw new FileNotFoundException("Couldn't find opus library");
+            return false;
         }
 
         private static void Load(string libraryPath)


### PR DESCRIPTION
To enable lazy-loading the library from custom locations.
This is probably not something we can upstream in this form, but it is more or less required for smooth integration with Unity.